### PR TITLE
Fix GitHub Actions workflow config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: Main
 on:
-- push
-- pull_request_target
+  push:
+    branches:
+      - main
+  pull_request: {}
 jobs:
   ci:
     strategy:
@@ -16,7 +18,7 @@ jobs:
     env:
       CI: true
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     name: AutoMerge
     needs: ci
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     steps:
     - uses: actions/github-script@v3
       with:


### PR DESCRIPTION
Fixes https://github.com/ruby-syntax-tree/syntax_tree-haml/issues/33.

We set CI to run on commits that are merged to main, and also on all commits on open pull requests. There is no need to specifically configure CI to run on merge commits, that is actually the default behavior of actions/checkout@v3 ([see docs](https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit)). And if we specify no trigger types for `pull_request`, then it will trigger on every commit to a pull request head branch (but not on commits to non-main branches that have no pull request), [see docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).