### PR TITLE
Fix hash parsing with Haml 6

### DIFF
--- a/lib/syntax_tree/haml/format.rb
+++ b/lib/syntax_tree/haml/format.rb
@@ -441,7 +441,7 @@ module SyntaxTree
         program = Ripper.sexp(source)
         type = program && program[1][0][0]
 
-        if type == :hash && (parsed = ::Haml::AttributeParser.parse(source))
+        if type == :hash && (parsed = ::Haml::AttributeParser.parse(source.tr("\n", ' ')))
           parsed.to_h { |key, value| [key, parse_attributes(value)] }
         elsif type == :string_literal
           SyntaxTree.parse(source).statements.body[0]

--- a/test/tag_test.rb
+++ b/test/tag_test.rb
@@ -146,4 +146,22 @@ class TagTest < Minitest::Test
   def test_interpolation_in_value
     assert_format("%p <small>hello</small>\"\#{1 + 2} little pigs\"")
   end
+
+  def test_multiline_attributes
+    assert_format(<<~HAML)
+      %ul.nav.nav-tabs.mb-4
+        %li.nav-item
+          %button.nav-link.active{
+            data: { bs_toggle: "tab", bs_target: "#file" },
+            type: "button"
+          }
+            File
+        %li.nav-item
+          %button.nav-link{
+            data: { bs_toggle: "tab", bs_target: "#video" },
+            type: "button"
+          }
+            Video
+    HAML
+  end
 end


### PR DESCRIPTION
This PR fixes #35 which describes a bug when formatting a multi-line hash as in this (correctly formatted) example:

```haml
%ul.nav.nav-tabs.mb-4
  %li.nav-item
    %button.nav-link.active{
      data: { bs_toggle: "tab", bs_target: "#file" },
      type: "button"
    }
      File
  %li.nav-item
    %button.nav-link{
      data: { bs_toggle: "tab", bs_target: "#video" },
      type: "button"
    }
      Video
```

With Haml 5, there is no problem. But with Haml 6, the **indention of the hash is removed** because `Haml::AttributeParser` seems (?!) not to allow line breaks while parsing. This results in the hash being treated as a `PlainPart` (no indention) rather than a `HashAttributesPart` (with indention).

Maybe this is a bug in Haml 6 (I haven't investigated this further), but to fix this here, the line breaks will be removed before parsing.

This PR adds a test which fails **without** the change and passes **with** the change.