### PR TITLE
keep unescape script node when child of tag

### DIFF
--- a/lib/syntax_tree/haml/format.rb
+++ b/lib/syntax_tree/haml/format.rb
@@ -16,7 +16,7 @@ module SyntaxTree
             .lines
             .each
             .with_index(1) do |line, index|
-              @literal_lines[index] = line.rstrip if line.start_with?("!")
+              @literal_lines[index] = line.strip if line.lstrip.start_with?("!")
             end
 
           super(source, *rest, options: options)

--- a/test/script_test.rb
+++ b/test/script_test.rb
@@ -22,4 +22,11 @@ class ScriptTest < Minitest::Test
   def test_unescape
     assert_format("!= hello")
   end
+
+  def test_child_unescape
+    assert_format(<<~HAML)
+      .container
+        != hello
+    HAML
+  end
 end


### PR DESCRIPTION
Hello! I found some cases when unescaping html with `!=` is erroneously being formatted as `=`.

First case is when the script node in question is indented, has fix + test in pr
Input:
```
.container
    != hello
```
Expected output:
```
.container
    != hello
```
Actual output:
```
.container
    = hello
```
-----
Second case is when the evaluation is on the same line as the tag, and this is an issue for all the following cases (currently failing).
```
  def test_preserve
    assert_format("%p~ foo")
  end

  def test_escape_html
    assert_format("%div&= foo")
  end

  def test_preserve_escape_html
    assert_format("%p&~ foo")
  end

  def test_unescape
    assert_format('%p!= foo')
  end
 ```
 I wasn't able to get to this yet, should I open an issue? 